### PR TITLE
chore: bump appdmg to ^0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "minimist": "^1.1.1"
   },
   "optionalDependencies": {
-    "appdmg": "^0.6.0"
+    "appdmg": "~0.6.4"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "minimist": "^1.1.1"
   },
   "optionalDependencies": {
-    "appdmg": "~0.6.4"
+    "appdmg": "^0.6.4"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,7 +373,7 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-appdmg@~0.6.4:
+appdmg@^0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/appdmg/-/appdmg-0.6.4.tgz#283b85cc761c1d924f2370bd5cdbd92824b12ef3"
   integrity sha512-YTilgNF0DF2DSRzGzzGDxaTMLXlhe3b3HB8RAaoJJ/VJXZbOlzIAcZ7gdPniHUVUuHjGwnS7fUMd4FvO2Rp94A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,7 +373,7 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-appdmg@^0.6.0:
+appdmg@~0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/appdmg/-/appdmg-0.6.4.tgz#283b85cc761c1d924f2370bd5cdbd92824b12ef3"
   integrity sha512-YTilgNF0DF2DSRzGzzGDxaTMLXlhe3b3HB8RAaoJJ/VJXZbOlzIAcZ7gdPniHUVUuHjGwnS7fUMd4FvO2Rp94A==


### PR DESCRIPTION
Closes #131

This fixes an issue with building on ARM64 devices running macOS 12.3.
See https://github.com/LinusU/node-appdmg/pull/205 for details.