### PR TITLE
refactor: `fs.rmdir` -> `fs.rm`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ async function build(opts) {
     }).on('finish', async () => {
       debug('appdmg finished!');
       debug('cleaning up temp config at `%s`', specDir);
-      await fs.rmdir(specDir, { recursive: true, maxRetries: 2 });
+      await fs.rm(specDir, { recursive: true, maxRetries: 2 });
       resolve(opts);
     }).on('error', reject);
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,6 +39,6 @@ describe('electron-installer-dmg', () => {
 
     afterEach(async () => fs.unlink(`${appPath}.dmg`));
 
-    after(async () => fs.rmdir(appPath, { recursive: true }));
+    after(async () => fs.rm(appPath, { recursive: true }));
   });
 });


### PR DESCRIPTION
```
(node:23706) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Node 16: https://nodejs.org/api/deprecations.html#DEP0147