### PR TITLE
test: use newer version of Electron

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,7 +21,7 @@ describe('electron-installer-dmg', () => {
     before(async function downloadElectron() {
       this.timeout(2 * MINUTES_IN_MS);
 
-      const zipPath = await download('2.0.4');
+      const zipPath = await download('18.2.0');
       await unzip(zipPath, { dir: appPath });
     });
 


### PR DESCRIPTION
Upgrades to the latest Electron stable release. Fixes tests not working on macOS arm64 machines since Electron 2 did not support Apple silicon.