### PR TITLE
README: Remove unused createDMG callback-parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ async function buildDMG() {
   });
 }
 ```
-#### createDMG(opts, callback)
+#### createDMG(opts)
 
 ##### `opts`
 


### PR DESCRIPTION
It's probably a leftover from an earlier version.