### PR TITLE
ci: update workflow dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
           architecture: 'x64'
           cache: yarn
+      - name: node-gyp v10
+        run: npm install -g node-gyp@10.1.0
       - name: Install
         run: yarn --frozen-lockfile
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Install
         run: yarn --frozen-lockfile
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           architecture: 'x64'
           cache: yarn
-      - name: node-gyp v10
-        run: npm install -g node-gyp@10.1.0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.2' 
       - name: Install
         run: yarn --frozen-lockfile
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332   # v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
-          python-version: '3.11'
+          python-version: '3.11' # distutils is required by node-gyp and dropped by python core in 3.12
       - name: Install
         run: yarn --frozen-lockfile
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
           cache: yarn
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.2' 
+          python-version: '3.2'
+          architecture: 'x64'
       - name: Install
         run: yarn --frozen-lockfile
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,14 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        node-version: [12.13.0, 14.x, 16.x]
+        node-version: [12.13.0, 14.x, 16.x, 18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@692973e   # v4.1.7
+      - uses: actions/setup-node@60edb5d # v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
+          architecture: 'x64'
           cache: yarn
       - name: Install
         run: yarn --frozen-lockfile
@@ -28,7 +29,7 @@ jobs:
       - name: Test
         run: yarn coverage
       - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c4 #v3.1.6
         with:
           file: ./coverage/lcov.info
           env_vars: NODE_VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           cache: yarn
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.2'
+          python-version: '3.2.5'
           architecture: 'x64'
       - name: Install
         run: yarn --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
         node-version: [12.13.0, 14.x, 16.x, 18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@692973e   # v4.1.7
-      - uses: actions/setup-node@60edb5d # v4.0.2
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332   # v4.1.7
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
           architecture: 'x64'
@@ -29,7 +29,7 @@ jobs:
       - name: Test
         run: yarn coverage
       - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@ab904c4 #v3.1.6
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 #v3.1.6
         with:
           file: ./coverage/lcov.info
           env_vars: NODE_VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,14 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        node-version: [12.13.0, 14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332   # v4.1.7
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
-          architecture: 'x64'
           cache: yarn
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.2.5'
-          architecture: 'x64'
       - name: Install
         run: yarn --frozen-lockfile
       - name: Lint

--- a/yarn.lock
+++ b/yarn.lock
@@ -2003,9 +2003,9 @@ murmur-32@^0.1.0:
     imul "^1.0.0"
 
 nan@^2.4.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
-  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.20.0.tgz#08c5ea813dd54ed16e5bd6505bf42af4f7838ca3"
+  integrity sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==
 
 nanoid@3.3.1:
   version "3.3.1"


### PR DESCRIPTION
This fixes CI by:

* Upgrading `nan` to 2.20.0 (ref https://github.com/nodejs/nan/pull/943)
* Pinning Python to 3.11 in the action.
* Dropping CI for Node.js 12 and Node.js 14 in preparation for a breaking change. This made it easier for tests to pass since older versions of Python were required for the versions of node-gyp that support Node 12 and 14, and those weren't available via `actions/setup-python`.