### PR TITLE
test: fix `fs.rmdir` deprecation warning

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -41,6 +41,6 @@ describe('electron-installer-dmg', () => {
 
     afterEach(async () => existsSync(fixtureDMGPath) ? fs.unlink(fixtureDMGPath) : null);
 
-    after(async () => fs.rmdir(appPath, { recursive: true }));
+    after(async () => fs.rm(appPath, { recursive: true }));
   });
 });


### PR DESCRIPTION
```
(node:23706) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Node 16: https://nodejs.org/api/deprecations.html#DEP0147

Supersedes #133